### PR TITLE
Use _results_number=0 in the Socorro query

### DIFF
--- a/addon/content.js
+++ b/addon/content.js
@@ -11,7 +11,7 @@ if (querystring.length > 0) {
     var iframe = document.createElement('iframe');
     iframe.src = 'https://ashughes1.github.io/bugzilla-socorro-lens/chart.htm?s=' + querystring;
     //iframe.src = 'file:///home/ashughes/Development/bugzilla-socorro-lens/chart.htm?s=' + querystring;
-    iframe.setAttribute('style', 'border:0; height:190px');
+    iframe.setAttribute('style', 'border:0; height:290px');
     var container = document.getElementById(selector);
     if (container) container.appendChild(iframe);
 }

--- a/chart.htm
+++ b/chart.htm
@@ -118,7 +118,7 @@
 					if (!globals.url[i]) globals.url[i] = "";
 					globals.url[i] = globals.url_base + signatures[i];
 					// Iterate through the Socorro data and create the chart data object
-					var url = "https://crash-stats.mozilla.com/api/SuperSearch/?" + signatures[i] + "&date=%3E%3D" + start_date + "&date=%3C%3D" + end_date + "&_histogram.date=_cardinality.install_time&_histogram_interval=1d";
+					var url = "https://crash-stats.mozilla.com/api/SuperSearch/?" + signatures[i] + "&date=%3E%3D" + start_date + "&date=%3C%3D" + end_date + "&_histogram.date=_cardinality.install_time&_histogram_interval=1d&_results_number=0";
 					url = url.replace("/?&signature", "/?signature");
 					d3.json(url, function(data) {
 						$.each(data, function(key, value) {

--- a/chart.htm
+++ b/chart.htm
@@ -19,8 +19,8 @@
     </style>
 </head>
 <body onload="loadGraph(window.location.search);">       
-    <div style="width:300px; height:150px;" id='chart' class='chart'></div>
-	<div style="width:300px; height:75px; margin-top:-35px; color:red; text-align:center; visibility:hidden;" id='warn'></div>
+    <div style="width:500px; height:250px;" id='chart' class='chart'></div>
+	<div style="width:500px; height:75px; margin-top:-35px; color:red; text-align:center; visibility:hidden;" id='warn'></div>
     <script src='metricsgraphics/main.js'></script>
     <script>
         var items = [];
@@ -115,8 +115,8 @@
 							items = MG.convert.date(items, 'date');
 							MG.data_graphic({
 								data: items,
-								width: 300,
-								height: 170,
+								width: 500,
+								height: 270,
 								target: document.getElementById('chart'),
 								x_accessor: 'date',
 								y_accessor: 'count',


### PR DESCRIPTION
The values in 'hits' are unused, so using _results_number=0 will speed up the query.
