### PR TITLE
Use '=' operator instead of '~' to avoid overreporting the number of crashes

### DIFF
--- a/addon/content.js
+++ b/addon/content.js
@@ -11,7 +11,7 @@ if (querystring.length > 0) {
     var iframe = document.createElement('iframe');
     iframe.src = 'https://ashughes1.github.io/bugzilla-socorro-lens/chart.htm?s=' + querystring;
     //iframe.src = 'file:///home/ashughes/Development/bugzilla-socorro-lens/chart.htm?s=' + querystring;
-    iframe.setAttribute('style', 'border:0; height:190px');
+    iframe.setAttribute('style', 'border:0; height:290px');
     var container = document.getElementById(selector);
     if (container) container.appendChild(iframe);
 }

--- a/chart.htm
+++ b/chart.htm
@@ -66,7 +66,7 @@
 			var j = 0;
 			$.each(signatures, function(i) {
 				if (result[j].length > 500) result[++j] = "";
-				result[j] = result[j] + "&signature=~" + signatures[i]
+				result[j] = result[j] + "&signature=%3D" + signatures[i]
 			});
 			
             return result;

--- a/chart.htm
+++ b/chart.htm
@@ -19,8 +19,8 @@
     </style>
 </head>
 <body onload="loadGraph(window.location.search);">       
-    <div style="width:300px; height:150px;" id='chart' class='chart'></div>
-	<div style="width:300px; height:75px; margin-top:-35px; color:red; text-align:center; visibility:hidden;" id='warn'></div>
+    <div style="width:500px; height:250px;" id='chart' class='chart'></div>
+	<div style="width:500px; height:75px; margin-top:-35px; color:red; text-align:center; visibility:hidden;" id='warn'></div>
     <script src='metricsgraphics/main.js'></script>
     <script>
         var items = [];
@@ -115,8 +115,8 @@
 							items = MG.convert.date(items, 'date');
 							MG.data_graphic({
 								data: items,
-								width: 300,
-								height: 170,
+								width: 500,
+								height: 270,
 								target: document.getElementById('chart'),
 								x_accessor: 'date',
 								y_accessor: 'count',


### PR DESCRIPTION
Fixes #14.
